### PR TITLE
Typify version paths

### DIFF
--- a/decomp_settings.pyi
+++ b/decomp_settings.pyi
@@ -92,7 +92,7 @@ class VersionPaths:
     ## Examples
 
     ```
-    target: "config/us/baserom_uncompressed.us.z64"
+    target: "config/us/baserom_decompressed.us.z64"
     ```
     """
 
@@ -125,7 +125,7 @@ class VersionPaths:
     ## Examples
 
     ```
-    compiled_target: "build/us/drmario64.us.z64"
+    compiled_target: "build/us/drmario64_uncompressed.us.z64"
     ```
     """
 
@@ -176,6 +176,28 @@ class VersionPaths:
 
     ```
     nonmatchings: "asm/rev0/nonmatchings"
+    ```
+    """
+
+    compressed_target: str | None
+    """
+    Path to the original target binary before decompression, if any.
+
+    ## Examples
+
+    ```
+    compressed_target: "config/usa/rom_original.z64"
+    ```
+    """
+
+    compressed_compiled_target: str | None
+    """
+    Path to the compressed binary produced by the build system, if any.
+
+    ## Examples
+
+    ```
+    compressed_compiled_target: "build/usa/compressed_rom.z64"
     ```
     """
 

--- a/decomp_settings.pyi
+++ b/decomp_settings.pyi
@@ -140,7 +140,7 @@ class VersionPaths:
     ```
     """
 
-    expected_dir: str
+    expected_dir: str | None
     """
     Directory containing the expected files used for comparison.
 
@@ -153,7 +153,7 @@ class VersionPaths:
     ```
     """
 
-    asm: str
+    asm: str | None
     """
     Directory containing disassembled assembly files.
 
@@ -168,7 +168,7 @@ class VersionPaths:
     ```
     """
 
-    nonmatchings: str
+    nonmatchings: str | None
     """
     Directory containing functions or files that have not yet been matched to the original binary.
 

--- a/decomp_settings.pyi
+++ b/decomp_settings.pyi
@@ -73,10 +73,112 @@ class Version:
     """
     The sha1 hash of the target executable. This can be used by tools to ensure the correct executable is being worked with.
     """
-    paths: dict[str, str]
+    paths: VersionPaths
     """
-    A map of path names to paths that tools may care about. Common paths would be baserom, asm, build, map, expected, etc.
+    A list of paths that tools may care about.
     """
+
+class VersionPaths:
+    """
+    Represents the set of important file and directory paths associated with a project version.
+
+    Each field corresponds to a specific artifact or directory relevant to decomp tools.
+    """
+
+    target: str
+    """
+    Path to the original target binary (e.g., the ROM or executable to decompile). Usually called "baserom" by many projects.
+
+    ## Examples
+
+    ```
+    target: "config/us/baserom_uncompressed.us.z64"
+    ```
+    """
+
+    build_dir: str
+    """
+    Directory where build artifacts are generated.
+
+    ## Examples
+
+    ```
+    build_dir: "build/ntsc-u/"
+    ```
+    """
+
+    map: str
+    """
+    Path to the map file generated during the build.
+
+    ## Examples
+
+    ```
+    map: "build/us/drmario64.us.map"
+    ```
+    """
+
+    compiled_target: str
+    """
+    Path to the binary produced by the project's build system.
+
+    ## Examples
+
+    ```
+    compiled_target: "build/us/drmario64.us.z64"
+    ```
+    """
+
+    elf: str | None
+    """
+    Path to the intermediary ELF file generated during the build, if any.
+
+    ## Examples
+
+    ```
+    elf: "build/pokemonsnap.elf"
+    ```
+    """
+
+    expected_dir: str
+    """
+    Directory containing the expected files used for comparison.
+
+    Many projects simply put a copy of their `build` directory inside this expected directory.
+
+    ## Examples
+
+    ```
+    expected_dir: "expected/"
+    ```
+    """
+
+    asm: str
+    """
+    Directory containing disassembled assembly files.
+
+    ## Examples
+
+    ```
+    asm: "asm/"
+    ```
+
+    ```
+    asm: "asm/rev0/"
+    ```
+    """
+
+    nonmatchings: str
+    """
+    Directory containing functions or files that have not yet been matched to the original binary.
+
+    ## Examples
+
+    ```
+    nonmatchings: "asm/rev0/nonmatchings"
+    ```
+    """
+
 
 class ToolOpts:
     """

--- a/src/config.rs
+++ b/src/config.rs
@@ -239,7 +239,7 @@ pub struct VersionPaths {
     /// ```yaml
     /// expected_dir: "expected/"
     /// ```
-    pub expected_dir: PathBuf,
+    pub expected_dir: Option<PathBuf>,
 
     /// Directory containing disassembled assembly files.
     ///
@@ -252,7 +252,7 @@ pub struct VersionPaths {
     /// ```yaml
     /// asm: "asm/rev0/"
     /// ```
-    pub asm: PathBuf,
+    pub asm: Option<PathBuf>,
     /// Directory containing functions or files that have not yet been matched to the original binary.
     ///
     /// ## Examples
@@ -260,7 +260,7 @@ pub struct VersionPaths {
     /// ```yaml
     /// nonmatchings: "asm/rev0/nonmatchings"
     /// ```
-    pub nonmatchings: PathBuf,
+    pub nonmatchings: Option<PathBuf>,
 
     /// Path to the original target binary before decompression, if any.
     ///

--- a/src/config.rs
+++ b/src/config.rs
@@ -194,7 +194,7 @@ pub struct VersionPaths {
     /// ## Examples
     ///
     /// ```yaml
-    /// target: "config/us/baserom_uncompressed.us.z64"
+    /// target: "config/us/baserom_decompressed.us.z64"
     /// ```
     target: PathBuf,
 
@@ -219,7 +219,7 @@ pub struct VersionPaths {
     /// ## Examples
     ///
     /// ```yaml
-    /// compiled_target: "build/us/drmario64.us.z64"
+    /// compiled_target: "build/us/drmario64_uncompressed.us.z64"
     /// ```
     compiled_target: PathBuf,
     /// Path to the intermediary ELF file generated during the build, if any.
@@ -262,6 +262,23 @@ pub struct VersionPaths {
     /// nonmatchings: "asm/rev0/nonmatchings"
     /// ```
     nonmatchings: PathBuf,
+
+    /// Path to the original target binary before decompression, if any.
+    ///
+    /// ## Examples
+    ///
+    /// ```yaml
+    /// compressed_target: "config/usa/rom_original.z64"
+    /// ```
+    compressed_target: Option<PathBuf>,
+    /// Path to the compressed binary produced by the build system, if any.
+    ///
+    /// ## Examples
+    ///
+    /// ```yaml
+    /// compressed_compiled_target: "build/usa/compressed_rom.z64"
+    /// ```
+    compressed_compiled_target: Option<PathBuf>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -168,14 +168,100 @@ pub struct Version {
     pub fullname: String,
     /// The sha1 hash of the target executable. This can be used by tools to ensure the correct executable is being worked with.
     pub sha1: Option<String>,
-    /// A map of path names to paths that tools may care about. Common paths would be baserom, asm, build, map, expected, etc.
-    pub paths: HashMap<String, PathBuf>,
+    /// A list of paths that tools may care about.
+    pub paths: VersionPaths,
 }
 
 impl Display for Version {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         f.write_fmt(format_args!("{}", self.fullname,))
     }
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+#[cfg_attr(
+    feature = "python_bindings",
+    pyclass(frozen, get_all, module = "decomp_settings")
+)]
+/// Represents the set of important file and directory paths associated with a project version.
+///
+/// Each field corresponds to a specific artifact or directory relevant to decomp tools.
+
+pub struct VersionPaths {
+    /// Path to the original target binary (e.g., the ROM or executable to decompile). Usually called "baserom" by many projects.
+    ///
+    /// ## Examples
+    ///
+    /// ```yaml
+    /// target: "config/us/baserom_uncompressed.us.z64"
+    /// ```
+    target: PathBuf,
+
+    /// Directory where build artifacts are generated.
+    ///
+    /// ## Examples
+    ///
+    /// ```yaml
+    /// build_dir: "build/ntsc-u/"
+    /// ```
+    build_dir: PathBuf,
+    /// Path to the map file generated during the build.
+    ///
+    /// ## Examples
+    ///
+    /// ```yaml
+    /// map: "build/us/drmario64.us.map"
+    /// ```
+    map: PathBuf,
+    /// Path to the binary produced by the project's build system.
+    ///
+    /// ## Examples
+    ///
+    /// ```yaml
+    /// compiled_target: "build/us/drmario64.us.z64"
+    /// ```
+    compiled_target: PathBuf,
+    /// Path to the intermediary ELF file generated during the build, if any.
+    ///
+    /// ## Examples
+    ///
+    /// ```yaml
+    /// elf: "build/pokemonsnap.elf"
+    /// ```
+    elf: Option<PathBuf>,
+
+    /// Directory containing the expected files used for comparison.
+    ///
+    /// Many projects simply put a copy of their `build` directory inside this expected directory.
+    ///
+    /// ## Examples
+    ///
+    /// ```yaml
+    /// expected_dir: "expected/"
+    /// ```
+    expected_dir: PathBuf,
+
+    /// Directory containing disassembled assembly files.
+    ///
+    /// ## Examples
+    ///
+    /// ```yaml
+    /// asm: "asm/"
+    /// ```
+    ///
+    /// ```yaml
+    /// asm: "asm/rev0/"
+    /// ```
+    asm: PathBuf,
+    /// Directory containing functions or files that have not yet been matched to the original binary.
+    ///
+    /// ## Examples
+    ///
+    /// ```yaml
+    /// nonmatchings: "asm/rev0/nonmatchings"
+    /// ```
+    nonmatchings: PathBuf,
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -84,7 +84,7 @@ impl ToolOpts {
 }
 
 #[cfg(feature = "python_bindings")]
-impl<'a, 'py> IntoPyObject<'py> for &'a AnyOpts {
+impl<'py> IntoPyObject<'py> for &AnyOpts {
     type Target = PyAny;
     type Output = Bound<'py, PyAny>;
     type Error = PyErr;
@@ -187,7 +187,6 @@ impl Display for Version {
 /// Represents the set of important file and directory paths associated with a project version.
 ///
 /// Each field corresponds to a specific artifact or directory relevant to decomp tools.
-
 pub struct VersionPaths {
     /// Path to the original target binary (e.g., the ROM or executable to decompile). Usually called "baserom" by many projects.
     ///
@@ -196,7 +195,7 @@ pub struct VersionPaths {
     /// ```yaml
     /// target: "config/us/baserom_decompressed.us.z64"
     /// ```
-    target: PathBuf,
+    pub target: PathBuf,
 
     /// Directory where build artifacts are generated.
     ///
@@ -205,7 +204,7 @@ pub struct VersionPaths {
     /// ```yaml
     /// build_dir: "build/ntsc-u/"
     /// ```
-    build_dir: PathBuf,
+    pub build_dir: PathBuf,
     /// Path to the map file generated during the build.
     ///
     /// ## Examples
@@ -213,7 +212,7 @@ pub struct VersionPaths {
     /// ```yaml
     /// map: "build/us/drmario64.us.map"
     /// ```
-    map: PathBuf,
+    pub map: PathBuf,
     /// Path to the binary produced by the project's build system.
     ///
     /// ## Examples
@@ -221,7 +220,7 @@ pub struct VersionPaths {
     /// ```yaml
     /// compiled_target: "build/us/drmario64_uncompressed.us.z64"
     /// ```
-    compiled_target: PathBuf,
+    pub compiled_target: PathBuf,
     /// Path to the intermediary ELF file generated during the build, if any.
     ///
     /// ## Examples
@@ -229,7 +228,7 @@ pub struct VersionPaths {
     /// ```yaml
     /// elf: "build/pokemonsnap.elf"
     /// ```
-    elf: Option<PathBuf>,
+    pub elf: Option<PathBuf>,
 
     /// Directory containing the expected files used for comparison.
     ///
@@ -240,7 +239,7 @@ pub struct VersionPaths {
     /// ```yaml
     /// expected_dir: "expected/"
     /// ```
-    expected_dir: PathBuf,
+    pub expected_dir: PathBuf,
 
     /// Directory containing disassembled assembly files.
     ///
@@ -253,7 +252,7 @@ pub struct VersionPaths {
     /// ```yaml
     /// asm: "asm/rev0/"
     /// ```
-    asm: PathBuf,
+    pub asm: PathBuf,
     /// Directory containing functions or files that have not yet been matched to the original binary.
     ///
     /// ## Examples
@@ -261,7 +260,7 @@ pub struct VersionPaths {
     /// ```yaml
     /// nonmatchings: "asm/rev0/nonmatchings"
     /// ```
-    nonmatchings: PathBuf,
+    pub nonmatchings: PathBuf,
 
     /// Path to the original target binary before decompression, if any.
     ///
@@ -270,7 +269,7 @@ pub struct VersionPaths {
     /// ```yaml
     /// compressed_target: "config/usa/rom_original.z64"
     /// ```
-    compressed_target: Option<PathBuf>,
+    pub compressed_target: Option<PathBuf>,
     /// Path to the compressed binary produced by the build system, if any.
     ///
     /// ## Examples
@@ -278,7 +277,7 @@ pub struct VersionPaths {
     /// ```yaml
     /// compressed_compiled_target: "build/usa/compressed_rom.z64"
     /// ```
-    compressed_compiled_target: Option<PathBuf>,
+    pub compressed_compiled_target: Option<PathBuf>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,14 +80,18 @@ pub fn read_config(path: PathBuf) -> Result<Config, DecompSettingsError> {
 #[cfg(feature = "python_bindings")]
 #[pymodule]
 fn decomp_settings(m: &Bound<'_, PyModule>) -> PyResult<()> {
-    use config::{AnyOpts, ToolOpts};
+    use config::{AnyOpts, ToolOpts, Version, VersionPaths};
 
     m.add_function(wrap_pyfunction!(scan_for_config, m)?)?;
     m.add_function(wrap_pyfunction!(scan_for_config_from, m)?)?;
     m.add_function(wrap_pyfunction!(read_config, m)?)?;
+
     m.add_class::<Config>()?;
+    m.add_class::<Version>()?;
+    m.add_class::<VersionPaths>()?;
     m.add_class::<ToolOpts>()?;
     m.add_class::<AnyOpts>()?;
+
     Ok(())
 }
 

--- a/test/arbitrary_tool.yaml
+++ b/test/arbitrary_tool.yaml
@@ -5,6 +5,18 @@ versions:
 - name: us
   fullname: US
   paths:
+    target: "pokemonsnap.z64"
+
+    build_dir: "build"
+    map: "build/pokemonsnap.map"
+    compiled_target: "build/pokemonsnap.z64"
+    elf: "build/pokemonsnap.elf"
+
+    expected_dir: "expected/"
+
+    asm: "asm"
+    nonmatchings: "asm/nonmatchings"
+
 tools:
   arbitrary_tool:
     meowp: 125

--- a/test/decomp.yaml
+++ b/test/decomp.yaml
@@ -6,12 +6,18 @@ versions:
   fullname: US
   sha1: edc7c49cc568c045fe48be0d18011c30f393cbaf
   paths:
-    baserom: "pokemonsnap.z64"
-    build: "build/pokemonsnap.z64"
+    target: "pokemonsnap.z64"
+
+    build_dir: "build"
+    map: "build/pokemonsnap.map"
+    compiled_target: "build/pokemonsnap.z64"
+    elf: "build/pokemonsnap.elf"
+
+    expected_dir: "expected/"
+
     asm: "asm"
     nonmatchings: "asm/nonmatchings"
-    map: "build/pokemonsnap.map"
-    elf: "build/pokemonsnap.elf"
+
 tools:
   decompme:
     preset: 125


### PR DESCRIPTION
Changed `versions.path` to be an struct instead of using a map of paths.

Renamed a few paths:
- `baserom` -> `target`
- `build` -> `compiled_target`

Added a few paths:
- `build_dir`: Path to the build directory.
- `expected_dir`: Path to the expected directory.
- `compressed_target` and `compressed_compiled_target`: Optional paths for projects that may have to deal with compressed roms
